### PR TITLE
Fixed wrong line break in generate_xml_list function

### DIFF
--- a/pipeline.ipynb
+++ b/pipeline.ipynb
@@ -131,8 +131,10 @@
     "def generate_xml_list(text):\n",
     "    result = \"<List>\"\n",
     "    li = [s.strip() for s in text.splitlines()]\n",
-    "    for l in li:\n",
-    "        result += \"<List-Element>\" + l+ \"</List-Element>\\n\"\n",
+    "    for i, l in enumerate(li):\n",
+    "        result += \"<List-Element>\" + l+ \"</List-Element>\"\n",
+    "        if not (len(li) - 1) == i:\n",
+    "            result += \"\\n\"\n",
     "\n",
     "    result += \"</List>\"\n",
     "    return result"

--- a/pipeline.py
+++ b/pipeline.py
@@ -86,9 +86,10 @@ def sanitize_text_test():
 def generate_xml_list(text):
     result = "<List>"
     li = [s.strip() for s in text.splitlines()]
-    for l in li:
-        result += "<List-Element>" + l + "</List-Element>\n"
-
+    for i, l in enumerate(li):
+        result += "<List-Element>" + l + "</List-Element>"
+        if not (len(li) - 1) == i:
+            result += "\n"
     result += "</List>"
     return result
 


### PR DESCRIPTION
After every loop iteration this function added a line break for each generated list element leading to the output being like that:

<List><List-Element>Hello World</List-Element>
<List-Element>hello / Seb</List-Element>
<List-Element>hello CDTM</List-Element>
</List>

The closing list tag caused than an extra line break in the layout in InDesign.

With this fix the output looks like that:

<List><List-Element>Hello World</List-Element>
<List-Element>hello / Seb</List-Element>
<List-Element>hello CDTM</List-Element></List>

Because the line break after a list element is only added if it is not the last element of the bullet point list. 

